### PR TITLE
adjust build process

### DIFF
--- a/src/DesignTime/DesignTime.fsproj
+++ b/src/DesignTime/DesignTime.fsproj
@@ -1,8 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework Condition="'$(Configuration)'=='Debug'">net461</TargetFramework>
-    <TargetFrameworks Condition="'$(Configuration)'=='Release'">netstandard2.0;net461</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.0;net461</TargetFrameworks>
     <AssemblyName>FSharp.Data.Npgsql.DesignTime</AssemblyName>
     <DefineConstants>NO_GENERATIVE</DefineConstants>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>

--- a/src/Runtime/FSharp.Data.Npgsql.nuspec
+++ b/src/Runtime/FSharp.Data.Npgsql.nuspec
@@ -22,6 +22,10 @@
   <files>
     <file src="bin\Release\net461\*.dll" target="lib\net461" />
     <file src="bin\Release\netstandard2.0\*.dll" target="lib\netstandard2.0" />
+    
+    <!-- we could omit FSharp.Core.dll here -->
+    <file src="bin\Release\typeproviders\fsharp41\netcoreapp2.0\*.dll" target="typeproviders\fsharp41\netcoreapp2.0" />
+    <file src="bin\Release\typeproviders\fsharp41\net461\*.dll" target="typeproviders\fsharp41\net461" />
   </files>
 </package>
 

--- a/src/Runtime/Runtime.fsproj
+++ b/src/Runtime/Runtime.fsproj
@@ -42,14 +42,19 @@
   </ItemGroup>
 
   <Target Name="BeforeBuild">
-    <MSBuild Projects="..\DesignTime\DesignTime.fsproj" Targets="Build" Properties="Configuration=$(Configuration);TargetFramework=$(TargetFramework)" />
+    <MSBuild Projects="..\DesignTime\DesignTime.fsproj" Targets="Build" Properties="Configuration=$(Configuration);TargetFramework=netcoreapp2.0" />
+    <MSBuild Projects="..\DesignTime\DesignTime.fsproj" Targets="Build" Properties="Configuration=$(Configuration);TargetFramework=net461" />
   </Target>
 
   <Target Name="AfterBuild">
-    <CreateItem Include="..\DesignTime\bin\$(Configuration)\$(TargetFramework)\*.dll;..\DesignTime\bin\$(Configuration)\$(TargetFramework)\*.pdb">
-      <Output TaskParameter="Include" ItemName="DesignTimeBinaries" />
+    <CreateItem Include="..\DesignTime\bin\$(Configuration)\netcoreapp2.0\*.dll;..\DesignTime\bin\$(Configuration)\netcoreapp2.0\*.pdb">
+      <Output TaskParameter="Include" ItemName="DesignTimeBinaries1" />
     </CreateItem>
-    <Copy SourceFiles="@(DesignTimeBinaries)" DestinationFolder="$(OutputPath)" />
+    <CreateItem Include="..\DesignTime\bin\$(Configuration)\net461\*.dll;..\DesignTime\bin\$(Configuration)\net461\*.pdb">
+      <Output TaskParameter="Include" ItemName="DesignTimeBinaries2" />
+    </CreateItem>
+    <Copy SourceFiles="@(DesignTimeBinaries1)" DestinationFolder="$(OutputPath)/../typeproviders/fsharp41/netcoreapp2.0" />
+    <Copy SourceFiles="@(DesignTimeBinaries2)" DestinationFolder="$(OutputPath)/../typeproviders/fsharp41/net461" />
   </Target>
 
   <Target Name="IncludeAllDlls">


### PR DESCRIPTION
@dmitry-a-morozov Can you help me a bit to iron out https://github.com/fsprojects/FSharp.TypeProviders.SDK/issues/244?

We can use this PR but I need help with testing s I don't have docker installed - can I test without it?  (I could install it but it tends to require hypervisor settings that conflict with the use of the Xamarin Android emulator I think)  

As a starter here are some possible adjustments to the build process, basically

* TPDTC cross-targets to both netcoreapp2.0 + net461 (not netstandard2.0)
* nuget places TPDTC components in "typeproviders"

This is only a starter to get me into the project and doesn't solve any problems.  I've just become aware that TPDTC targeting netcoreapp2.0 instead of netstandard2.0 is problably a good thing because of 