### PR TITLE
Fix bytea column select

### DIFF
--- a/src/Runtime/ISqlCommand.fs
+++ b/src/Runtime/ISqlCommand.fs
@@ -142,7 +142,7 @@ type ``ISqlCommand Implementation``(cfg: DesignTimeConfig, connection, commandTi
                 
             //TO DO: add extended property on column to mark enums
             let maybeEnum = expectedType = typeof<string> && actualType = typeof<obj>
-            let maybeArray = expectedType.IsArray && actualType = typeof<Array>
+            let maybeArray = (expectedType = typeof<Array> || expectedType.IsArray) && (actualType = typeof<Array> || actualType.IsArray)
             let typeless = expectedType = typeof<obj> && actualType = typeof<string>
             if (expectedName <> "" && actualName <> expectedName) 
                 || (actualType <> expectedType && not (maybeArray || maybeEnum) && not typeless)

--- a/tests/NpgsqlCmdTests.fs
+++ b/tests/NpgsqlCmdTests.fs
@@ -400,6 +400,12 @@ let updateWithEnum() =
         )
     )
 
+[<Fact>]
+let selectBytea() =
+    use cmd = new NpgsqlCommand<"SELECT picture FROM public.staff WHERE staff_id = 1", dvdRental, SingleRow = true>(dvdRental)
+    let actual = cmd.Execute().Value.Value
+    let expected = [|137uy; 80uy; 78uy; 71uy; 13uy; 10uy; 90uy; 10uy|]
+    Assert.Equal<byte>(expected, actual)
  
 //[<Fact>]
 //let npPkTable() =

--- a/tests/NpgsqlConnectionTests.fs
+++ b/tests/NpgsqlConnectionTests.fs
@@ -526,6 +526,14 @@ let ``column "p1_00" does not exist``() =
         use cmd = DvdRental.CreateCommand<"select title from public.film where film_id = @id", SingleRow = true, XCtor = true>(conn, tx)
         Assert.Equal( Some title, cmd.Execute(id.Value))
 
+
+[<Fact>]
+let selectBytea() =
+    use cmd = DvdRental.CreateCommand<"SELECT picture FROM public.staff WHERE staff_id = 1", SingleRow = true>(dvdRental)
+    let actual = cmd.Execute().Value.Value
+    let expected = [|137uy; 80uy; 78uy; 71uy; 13uy; 10uy; 90uy; 10uy|]
+    Assert.Equal<byte>(expected, actual)
+
 [<Literal>]
 let lims = "Host=localhost;Username=postgres;Password=postgres;Database=lims"
 


### PR DESCRIPTION
Fixes #35.

`NpgsqlDataReader.GetFieldType` returns `typeof<byte[]>` for `bytea` columns.