### PR TITLE
BUG: fix timestamptz datetime conversion in case of datatable api

### DIFF
--- a/src/DesignTime/DesignTime.fsproj
+++ b/src/DesignTime/DesignTime.fsproj
@@ -5,6 +5,7 @@
     <AssemblyName>FSharp.Data.Npgsql.DesignTime</AssemblyName>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
     <DebugType>full</DebugType>
+    <Deterministic>false</Deterministic>
     <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <DisableImplicitFSharpCoreReference>true</DisableImplicitFSharpCoreReference>

--- a/src/DesignTime/InformationSchema.fs
+++ b/src/DesignTime/InformationSchema.fs
@@ -175,14 +175,16 @@ type Column =
             then typedefof<_ option>.MakeGenericType this.ClrType
             else this.ClrType
 
+
     member this.ToDataColumnExpr() =
         let typeName = 
             let clrType = if this.ClrType.IsArray then typeof<Array> else this.ClrType
             clrType.PartiallyQualifiedName
-
-        let localDateTimeMode = this.DataType.Name = "timestamptz" && this.ClrType = typeof<DateTime>
+     
+        let isTimestampTz = this.DataType.Name = "timestamptz" && this.ClrType = typeof<DateTime>
+        let isTimestamp = this.DataType.Name = "timestamp" && this.ClrType = typeof<DateTime>
         let isEnum = this.UDT.Value |> Option.exists (fun x -> not x.IsArray)
-
+        
         <@@ 
             let x = new DataColumn( %%Expr.Value(this.Name), Type.GetType( typeName, throwOnError = true))
 
@@ -191,16 +193,25 @@ type Column =
             x.ReadOnly <- %%Expr.Value(this.ReadOnly)
 
             if x.DataType = typeof<string> then x.MaxLength <- %%Expr.Value(this.MaxLength)
-            if localDateTimeMode then x.DateTimeMode <- DataSetDateTime.Local
-
+            
+            if isTimestampTz then
+                //https://github.com/npgsql/npgsql/issues/1076#issuecomment-355400785
+                x.DateTimeMode <- DataSetDateTime.Local
+                //https://www.npgsql.org/doc/types/datetime.html#detailed-behavior-sending-values-to-the-database
+                x.ExtendedProperties.Add(%%Expr.Value(box SchemaTableColumn.ProviderType), %%Expr.Value(box NpgsqlDbType.TimestampTz))
+            elif isTimestamp then
+                //https://github.com/npgsql/npgsql/issues/1076#issuecomment-355400785
+                x.DateTimeMode <- DataSetDateTime.Local
+                //https://www.npgsql.org/doc/types/datetime.html#detailed-behavior-sending-values-to-the-database
+                x.ExtendedProperties.Add(%%Expr.Value(box SchemaTableColumn.ProviderType), %%Expr.Value(box NpgsqlDbType.Timestamp))
+            elif isEnum then
+                // value is an enum and should be sent to npgsql as unknown (auto conversion from string to appropriate enum type)
+                x.ExtendedProperties.Add(%%Expr.Value(box SchemaTableColumn.ProviderType), %%Expr.Value(box NpgsqlDbType.Unknown))
+            
             x.ExtendedProperties.Add(%%Expr.Value(box SchemaTableColumn.IsKey), %%Expr.Value(box this.PartOfPrimaryKey))
             x.ExtendedProperties.Add(%%Expr.Value(box SchemaTableColumn.AllowDBNull), %%Expr.Value(box this.Nullable))
             x.ExtendedProperties.Add(%%Expr.Value(box SchemaTableColumn.BaseSchemaName), %%Expr.Value(box this.BaseSchemaName))
             x.ExtendedProperties.Add(%%Expr.Value(box SchemaTableColumn.BaseTableName), %%Expr.Value(box this.BaseTableName))
-            if isEnum
-            then
-                x.ExtendedProperties.Add(%%Expr.Value(box SchemaTableColumn.ProviderType), %%Expr.Value(box NpgsqlDbType.Unknown))
-
             x
         @@>
     

--- a/src/DesignTime/NpgsqlConnectionProvider.fs
+++ b/src/DesignTime/NpgsqlConnectionProvider.fs
@@ -158,11 +158,8 @@ let createTableTypes(connectionString: string, item: DbSchemaLookupItem, fsx, is
                         use x = new NpgsqlCommandBuilder()
                         sprintf "%s.%s" (x.QuoteIdentifier item.Schema.Name) (x.QuoteIdentifier tableName)
 
-                    let cmdText =  
-                        columns
-                        |> List.map(fun c ->  c.Name)
-                        |> String.concat " ,"
-                        |> sprintf "SELECT %s FROM %s" twoPartTableName
+                    let columns = columns |> List.map(fun c ->  c.Name) |> String.concat " ,"
+                    let cmdText = sprintf "SELECT %s FROM %s" columns twoPartTableName
 
                     <@@ 
                         let selectCommand = new NpgsqlCommand(cmdText)


### PR DESCRIPTION
This PR fixes bug with DateTime insertion in case of insertion via DataTable api.
In case of 'timestamp' column type, - no value conversion is performed + DateTime.Kind is ignored, inline with Npgsql behavior.
In case of 'timestamptz' column type, - value conversion for dates with Kind Unspecified/Local is performed by Npgsql internally, - we achive this by specifying provider type for DataColumn to TimeStamptz.

Once merged, - insertion of dates to timestamptz column via TypeProvider.DataTable / TypeProvider.DbCommand will result in same behavior as executing NpgslCommand with TimestampTz parameter.
![image](https://user-images.githubusercontent.com/12952261/67678160-c892e400-f93a-11e9-89cb-1f28fded1433.png)