### PR TITLE
Fix "timestamp with timezone" mapping into DateTimeOffset

### DIFF
--- a/src/DesignTime/InformationSchema.fs
+++ b/src/DesignTime/InformationSchema.fs
@@ -69,7 +69,7 @@ let private builtins = [
     "date", typeof<DateTime>
     "interval", typeof<TimeSpan>
     "timestamp without time zone", typeof<DateTime>; "timestamp", typeof<DateTime>   
-    "timestamp with time zone", typeof<DateTime>; "timestamptz", typeof<DateTime>
+    "timestamp with time zone", typeof<DateTimeOffset>; "timestamptz", typeof<DateTimeOffset>
     "time without time zone", typeof<TimeSpan>; "time", typeof<TimeSpan>
     "time with time zone", typeof<DateTimeOffset>; "timetz", typeof<DateTimeOffset>
 


### PR DESCRIPTION
Columns of type "timestamp with timezone" should have time DateTimeOffset instead of DateTime because otherwise you lose the timezone information