### PR TITLE
Quotation optimizations

### DIFF
--- a/src/DesignTime/InformationSchema.fs
+++ b/src/DesignTime/InformationSchema.fs
@@ -179,52 +179,56 @@ type Column =
         else
             if nullable then typedefof<_ option>.MakeGenericType this.ClrType else this.ClrType
 
-    member this.ToDataColumnExpr() =
+    member this.ToDataColumnExpr(includeExtendedPropertiesAndDateTimeMode: bool) =
         let typeName = 
             let clrType = if this.ClrType.IsArray then typeof<Array> else this.ClrType
             clrType.PartiallyQualifiedName
      
-        let isTimestampTz = this.DataType.Name = "timestamptz" && this.ClrType = typeof<DateTime>
-        let isTimestamp = this.DataType.Name = "timestamp" && this.ClrType = typeof<DateTime>
-        let isJson = this.DataType.Name = "json"
-        let isJsonb = this.DataType.Name = "jsonb"
-        let isEnum = (not this.ClrType.IsArray) && this.DataType.IsUserDefinedType
-        
-        <@@ 
-            let x = new DataColumn( %%Expr.Value(this.Name), Type.GetType( typeName, throwOnError = true))
-
-            x.AutoIncrement <- %%Expr.Value(this.AutoIncrement)
-            x.AllowDBNull <- %%Expr.Value(this.Nullable || this.HasDefaultConstraint)
-            x.ReadOnly <- %%Expr.Value(this.ReadOnly)
-
-            if x.DataType = typeof<string> then x.MaxLength <- %%Expr.Value(this.MaxLength)
+        if not includeExtendedPropertiesAndDateTimeMode then
+            let getTypeExpr = Expr.Call(typeof<Type>.GetMethod("GetType", [| typeof<string>; typeof<bool> |]), [ Expr.Value typeName; Expr.Value true ])
+            Expr.NewObject(typeof<DataColumn>.GetConstructor [| typeof<string>; typeof<Type> |], [ Expr.Value this.Name; getTypeExpr ])
+        else
+            let isTimestampTz = this.DataType.Name = "timestamptz" && this.ClrType = typeof<DateTime>
+            let isTimestamp = this.DataType.Name = "timestamp" && this.ClrType = typeof<DateTime>
+            let isJson = this.DataType.Name = "json"
+            let isJsonb = this.DataType.Name = "jsonb"
+            let isEnum = (not this.ClrType.IsArray) && this.DataType.IsUserDefinedType
             
-            // control flow must be specified via simple bool switches as we are inside of quotation expression.
-            // Expr.Value can contain only boxed primitive types (not variables)
-            if isTimestampTz then
-                //https://github.com/npgsql/npgsql/issues/1076#issuecomment-355400785
-                x.DateTimeMode <- DataSetDateTime.Local
-                //https://www.npgsql.org/doc/types/datetime.html#detailed-behavior-sending-values-to-the-database
-                x.ExtendedProperties.Add(%%Expr.Value(box SchemaTableColumn.ProviderType), %%Expr.Value(box NpgsqlDbType.TimestampTz))
-            elif isTimestamp then
-                //https://github.com/npgsql/npgsql/issues/1076#issuecomment-355400785
-                x.DateTimeMode <- DataSetDateTime.Local
-                //https://www.npgsql.org/doc/types/datetime.html#detailed-behavior-sending-values-to-the-database
-                x.ExtendedProperties.Add(%%Expr.Value(box SchemaTableColumn.ProviderType), %%Expr.Value(box NpgsqlDbType.Timestamp))
-            elif isEnum then
-                // value is an enum and should be sent to npgsql as unknown (auto conversion from string to appropriate enum type)
-                x.ExtendedProperties.Add(%%Expr.Value(box SchemaTableColumn.ProviderType), %%Expr.Value(box NpgsqlDbType.Unknown))
-            elif isJson then
-                x.ExtendedProperties.Add(%%Expr.Value(box SchemaTableColumn.ProviderType), %%Expr.Value(box NpgsqlDbType.Json))
-            elif isJsonb then
-                x.ExtendedProperties.Add(%%Expr.Value(box SchemaTableColumn.ProviderType), %%Expr.Value(box NpgsqlDbType.Jsonb))
-            
-            x.ExtendedProperties.Add(%%Expr.Value(box SchemaTableColumn.IsKey), %%Expr.Value(box this.PartOfPrimaryKey))
-            x.ExtendedProperties.Add(%%Expr.Value(box SchemaTableColumn.AllowDBNull), %%Expr.Value(box this.Nullable))
-            x.ExtendedProperties.Add(%%Expr.Value(box SchemaTableColumn.BaseSchemaName), %%Expr.Value(box this.BaseSchemaName))
-            x.ExtendedProperties.Add(%%Expr.Value(box SchemaTableColumn.BaseTableName), %%Expr.Value(box this.BaseTableName))
-            x
-        @@>
+            <@@ 
+                let x = new DataColumn( %%Expr.Value(this.Name), Type.GetType( typeName, throwOnError = true))
+
+                x.AutoIncrement <- %%Expr.Value(this.AutoIncrement)
+                x.AllowDBNull <- %%Expr.Value(this.Nullable || this.HasDefaultConstraint)
+                x.ReadOnly <- %%Expr.Value(this.ReadOnly)
+
+                if x.DataType = typeof<string> then x.MaxLength <- %%Expr.Value(this.MaxLength)
+                
+                // control flow must be specified via simple bool switches as we are inside of quotation expression.
+                // Expr.Value can contain only boxed primitive types (not variables)
+                if isTimestampTz then
+                    //https://github.com/npgsql/npgsql/issues/1076#issuecomment-355400785
+                    x.DateTimeMode <- DataSetDateTime.Local
+                    //https://www.npgsql.org/doc/types/datetime.html#detailed-behavior-sending-values-to-the-database
+                    x.ExtendedProperties.Add(%%Expr.Value(box SchemaTableColumn.ProviderType), %%Expr.Value(box NpgsqlDbType.TimestampTz))
+                elif isTimestamp then
+                    //https://github.com/npgsql/npgsql/issues/1076#issuecomment-355400785
+                    x.DateTimeMode <- DataSetDateTime.Local
+                    //https://www.npgsql.org/doc/types/datetime.html#detailed-behavior-sending-values-to-the-database
+                    x.ExtendedProperties.Add(%%Expr.Value(box SchemaTableColumn.ProviderType), %%Expr.Value(box NpgsqlDbType.Timestamp))
+                elif isEnum then
+                    // value is an enum and should be sent to npgsql as unknown (auto conversion from string to appropriate enum type)
+                    x.ExtendedProperties.Add(%%Expr.Value(box SchemaTableColumn.ProviderType), %%Expr.Value(box NpgsqlDbType.Unknown))
+                elif isJson then
+                    x.ExtendedProperties.Add(%%Expr.Value(box SchemaTableColumn.ProviderType), %%Expr.Value(box NpgsqlDbType.Json))
+                elif isJsonb then
+                    x.ExtendedProperties.Add(%%Expr.Value(box SchemaTableColumn.ProviderType), %%Expr.Value(box NpgsqlDbType.Jsonb))
+                
+                x.ExtendedProperties.Add(%%Expr.Value(box SchemaTableColumn.IsKey), %%Expr.Value(box this.PartOfPrimaryKey))
+                x.ExtendedProperties.Add(%%Expr.Value(box SchemaTableColumn.AllowDBNull), %%Expr.Value(box this.Nullable))
+                x.ExtendedProperties.Add(%%Expr.Value(box SchemaTableColumn.BaseSchemaName), %%Expr.Value(box this.BaseSchemaName))
+                x.ExtendedProperties.Add(%%Expr.Value(box SchemaTableColumn.BaseTableName), %%Expr.Value(box this.BaseTableName))
+                x
+            @@>
     
 type DbSchemaLookupItem =
     { Schema : Schema

--- a/src/DesignTime/NpgsqlCommandProvider.fs
+++ b/src/DesignTime/NpgsqlCommandProvider.fs
@@ -66,7 +66,7 @@ let internal createRootType
                 Parameters = %%Expr.NewArray( typeof<NpgsqlParameter>, parameters |> List.map QuotationsFactory.ToSqlParam)
                 ResultType = resultType
                 SingleRow = singleRow
-                ResultSets = %%Expr.NewArray(typeof<ResultSetDefinition>, QuotationsFactory.BuildResultSetDefinitions outputColumns returnTypes)
+                ResultSets = %%Expr.NewArray(typeof<ResultSetDefinition>, QuotationsFactory.BuildResultSetDefinitions outputColumns returnTypes resultType)
                 UseLegacyPostgis = useLegacyPostgis
                 Prepare = prepare
             } @@>

--- a/src/DesignTime/NpgsqlConnectionProvider.fs
+++ b/src/DesignTime/NpgsqlConnectionProvider.fs
@@ -78,7 +78,7 @@ let addCreateCommandMethod(connectionString, rootType: ProvidedTypeDefinition, c
                         Parameters = %%Expr.NewArray( typeof<NpgsqlParameter>, parameters |> List.map QuotationsFactory.ToSqlParam)
                         ResultType = %%Expr.Value(resultType)
                         SingleRow = singleRow
-                        ResultSets = %%Expr.NewArray(typeof<ResultSetDefinition>, QuotationsFactory.BuildResultSetDefinitions outputColumns returnTypes)
+                        ResultSets = %%Expr.NewArray(typeof<ResultSetDefinition>, QuotationsFactory.BuildResultSetDefinitions outputColumns returnTypes resultType)
                         UseLegacyPostgis = useLegacyPostgis
                         Prepare = prepare
                     } @@>
@@ -130,7 +130,7 @@ let createTableTypes(connectionString: string, customTypes : Map<string, Provide
             do //ctor
                 let invokeCode _ = 
 
-                    let columnExprs = [ for c in columns -> c.ToDataColumnExpr() ]
+                    let columnExprs = [ for c in columns -> c.ToDataColumnExpr(true) ]
 
                     let twoPartTableName = 
                         use x = new NpgsqlCommandBuilder()

--- a/src/DesignTime/QuotationsFactory.fs
+++ b/src/DesignTime/QuotationsFactory.fs
@@ -59,9 +59,9 @@ type internal QuotationsFactory private() =
     [<Literal>]
     static let prohibitDesignTimeConnStrReUse = "Design-time connection string re-use allowed at run-time only when executed inside FSI."
 
-    static let getValueAtIndex = typeof<Array>.GetMethod("GetValue", [| typeof<int> |])
+    static let getValueAtIndex = typeof<Unit>.Assembly.GetType("Microsoft.FSharp.Collections.ArrayModule").GetMethod("Get").MakeGenericMethod(typeof<obj>)
 
-    static member internal GetValueAtIndexExpr arrayExpr index = Expr.Call(arrayExpr, getValueAtIndex, [ Expr.Value index ])
+    static member internal GetValueAtIndexExpr arrayExpr index = Expr.Call(getValueAtIndex, [ arrayExpr; Expr.Value index ])
 
     static member internal GetBody(methodName, specialization, [<ParamArray>] bodyFactoryArgs : obj[]) =
         

--- a/src/DesignTime/QuotationsFactory.fs
+++ b/src/DesignTime/QuotationsFactory.fs
@@ -615,13 +615,13 @@ type internal QuotationsFactory private() =
         then
             returnType.Single |> declaringType.AddMember
 
-    static member internal BuildResultSetDefinitions (outputColumns: Column list list) (returnTypes: ReturnType list) =
+    static member internal BuildResultSetDefinitions (outputColumns: Column list list) (returnTypes: ReturnType list) resultType =
         List.zip outputColumns returnTypes
         |> List.map (fun (outputColumns, returnType) ->
             <@@ {
                 Row2ItemMapping = %%returnType.Row2ItemMapping
                 SeqItemTypeName = %%returnType.SeqItemTypeName
-                ExpectedColumns = %%Expr.NewArray(typeof<DataColumn>, [ for c in outputColumns -> c.ToDataColumnExpr() ])
+                ExpectedColumns = %%Expr.NewArray(typeof<DataColumn>, [ for c in outputColumns -> c.ToDataColumnExpr((resultType = ResultType.DataTable)) ])
             } @@>)
 
     static member internal AddTopLevelTypes (cmdProvidedType: ProvidedTypeDefinition) parameters resultType customTypes returnTypes (outputColumns: Column list list) =

--- a/src/DesignTime/QuotationsFactory.fs
+++ b/src/DesignTime/QuotationsFactory.fs
@@ -251,7 +251,7 @@ type internal QuotationsFactory private() =
 
         recordType.AddMembers properties
 
-        let ctor = ProvidedConstructor(ctorParameters, fun args -> Expr.NewArray(typeof<obj>, args))
+        let ctor = ProvidedConstructor(ctorParameters, fun args -> Expr.NewArray(typeof<obj>, List.map (fun arg -> Expr.Coerce(arg, typeof<obj>)) args))
         recordType.AddMember ctor
         
         recordType

--- a/tests/NpgsqlConnectionTests.fs
+++ b/tests/NpgsqlConnectionTests.fs
@@ -709,6 +709,19 @@ let ``One select and two updates reader async``() =
 
     Assert.Equal (1, resultSets)
 
+[<Fact>]
+let ``Can instantiate provided record``() =
+    let fname = "a"
+    let lname = "b"
+    let id = 1
+    let time = DateTime (2020, 1, 1)
+    let actual = DvdRental.Commands.``CreateCommand,CommandText"select * from actor limit 5; select * from film limit 5"``.ResultSets.Record1 (id, fname, lname, time)
+
+    Assert.Equal (actual.actor_id, id)
+    Assert.Equal (actual.first_name, fname)
+    Assert.Equal (actual.last_name, lname)
+    Assert.Equal (actual.last_update, time)
+
 [<Literal>]
 let lims = "Host=localhost;Username=postgres;Password=postgres;Database=lims"
 


### PR DESCRIPTION
I don't believe it's necessary to use a dictionary with design time property names, because we can rely on runtime column verification. Therefore, records can be erased to an array, providing an order of magnitude better runtime performance at a fraction of the memory footprint, and the quotations end up a lot simpler. It would be great if you could measure if that makes any difference during design time.

Furthermore, the `rowMapping` quotation could possibly be removed in the future completely, since it's based on result set definitions, which are passed to the runtime bit too