### PR TITLE
Support composite types

### DIFF
--- a/src/DesignTime/InformationSchema.fs
+++ b/src/DesignTime/InformationSchema.fs
@@ -262,7 +262,8 @@ type Parameter =
       Precision: byte
       Scale : byte
       Optional: bool
-      DataType: DataType }
+      DataType: DataType
+      IsComposite: bool }
     with
    
     member this.Size = this.MaxLength
@@ -351,7 +352,8 @@ let extractParametersAndOutputColumns(connectionString, commandText, resultType,
               Precision = p.Precision
               Scale = p.Scale
               Optional = allParametersOptional 
-              DataType = DataType.Create(p.PostgresType) } ]
+              DataType = DataType.Create(p.PostgresType)
+              IsComposite = p.PostgresType :? PostgresCompositeType } ]
     
     let enums =  
         outputColumns 

--- a/src/DesignTime/NpgsqlConnectionProvider.fs
+++ b/src/DesignTime/NpgsqlConnectionProvider.fs
@@ -201,6 +201,12 @@ let createRootType
                 es.AddMember t
                 let udtTypeName = sprintf "%s.%s" enum.Schema enum.Name
                 yield udtTypeName, t
+
+            for (KeyValue(_, composite)) in schemaLookups.Schemas.[schemaType.Name].CompositeTypes do
+                es.AddMember composite
+                let udtTypeName = sprintf "%s.%s" schemaType.Name composite.Name
+                yield udtTypeName, composite
+
             schemaType.AddMember es
         ] |> Map.ofList
         

--- a/src/DesignTime/QuotationsFactory.fs
+++ b/src/DesignTime/QuotationsFactory.fs
@@ -85,16 +85,19 @@ type internal QuotationsFactory private() =
         let dbType = p.NpgsqlDbType
         let isFixedLength = p.DataType.IsFixedLength
 
-        <@@ 
-            let x = NpgsqlParameter(name, dbType, Direction = %%Expr.Value p.Direction)
+        if p.IsComposite then
+            <@@ NpgsqlParameter(ParameterName = %%Expr.Value name, Direction = %%Expr.Value p.Direction, DataTypeName = %%Expr.Value p.DataType.FullName) @@>
+        else
+            <@@ 
+                let x = NpgsqlParameter(name, dbType, Direction = %%Expr.Value p.Direction)
 
-            if not isFixedLength then x.Size <- %%Expr.Value p.Size 
+                if not isFixedLength then x.Size <- %%Expr.Value p.Size 
 
-            x.Precision <- %%Expr.Value p.Precision
-            x.Scale <- %%Expr.Value p.Scale
+                x.Precision <- %%Expr.Value p.Precision
+                x.Scale <- %%Expr.Value p.Scale
 
-            x
-        @@>
+                x
+            @@>
 
     static member internal GetNullableValueFromDataRow<'T>(exprArgs : Expr list, name : string) =
         <@

--- a/src/Runtime/Utils.fs
+++ b/src/Runtime/Utils.fs
@@ -22,12 +22,16 @@ type Utils private() =
     static member private CreateOptionType typeParam =
         typeof<unit option>.GetGenericTypeDefinition().MakeGenericType([| typeParam |])
     
-    static member private MakeOptionValue typeParam v isSome =
-        let optionType = Utils.CreateOptionType typeParam
+    static member GetOptionCaseInfos optionType =
         let cases = FSharp.Reflection.FSharpType.GetUnionCases(optionType)
         let cases = cases |> Array.partition (fun x -> x.Name = "Some")
         let someCase = fst cases |> Array.exactlyOne
         let noneCase = snd cases |> Array.exactlyOne
+        someCase, noneCase
+
+    static member private MakeOptionValue typeParam v isSome =
+        let optionType = Utils.CreateOptionType typeParam
+        let someCase, noneCase = Utils.GetOptionCaseInfos optionType
         let relevantCase, args =
             match isSome with
             | true -> someCase, [| v |]

--- a/tests/NpgsqlCmdTests.fs
+++ b/tests/NpgsqlCmdTests.fs
@@ -637,6 +637,18 @@ let ``Queries against system catalogs work``() =
     let actual = cmd.Execute()
     Assert.True(actual |> List.map (fun x -> x.name.Value) |> List.length > 0) 
  
+[<Literal>]
+let selectFromCompositesTableId5 = "select * from table_with_composites where id = 5"
+
+[<Fact>]
+let ``Composite type fields have correct values``() =
+    use cmd = new NpgsqlCommand<selectFromCompositesTableId5, dvdRental>(dvdRental)
+    let actual = cmd.Execute().Head
+    
+    Assert.Equal (Some 42L, actual.simple.some_number)
+    Assert.Equal (None, actual.simple.some_text)
+    Assert.Equal (Some [| 1; 2 |], actual.simple.some_array)
+
 //[<Fact>]
 //let npPkTable() =
 //    use cmd =

--- a/tests/NpgsqlConnectionTests.fs
+++ b/tests/NpgsqlConnectionTests.fs
@@ -775,6 +775,26 @@ let ``Record rows contain different values``() =
 
     Assert.NotEqual (actual.[0].staff_id, actual.[1].staff_id)
 
+[<Fact>]
+let ``Can instantiate composite type``() =
+    let arr = [| 3 |]
+    let num = 50L
+    let text = "blah"
+    let actual = DvdRental.``public``.Types.simple_type (arr, text, num)
+
+    Assert.Equal (Some num, actual.some_number)
+    Assert.Equal (Some text, actual.some_text)
+    Assert.Equal (Some arr, actual.some_array)
+
+[<Fact>]
+let ``Composite type fields have correct values``() =
+    use cmd = DvdRental.CreateCommand<selectFromCompositesTableId5>(dvdRental)
+    let actual = cmd.Execute().Head
+    
+    Assert.Equal (Some 42L, actual.simple.some_number)
+    Assert.Equal (None, actual.simple.some_text)
+    Assert.Equal (Some [| 1; 2 |], actual.simple.some_array)
+
 //[<Literal>]
 //let lims = "Host=localhost;Username=postgres;Password=postgres;Database=lims"
 

--- a/tests/NpgsqlConnectionTests.fs
+++ b/tests/NpgsqlConnectionTests.fs
@@ -795,6 +795,31 @@ let ``Composite type fields have correct values``() =
     Assert.Equal (None, actual.simple.some_text)
     Assert.Equal (Some [| 1; 2 |], actual.simple.some_array)
 
+[<Fact>]
+let ``Composite type fields have correct values tuple``() =
+    use cmd = DvdRental.CreateCommand<selectFromCompositesTableId5, ResultType = ResultType.Tuples>(dvdRental)
+    let (actual, _, _) = cmd.Execute().Head
+    
+    Assert.Equal (Some 42L, actual.some_number)
+    Assert.Equal (None, actual.some_text)
+    Assert.Equal (Some [| 1; 2 |], actual.some_array)
+
+[<Fact>]
+let ``Composite type fields have correct values data table``() =
+    use cmd = DvdRental.CreateCommand<selectFromCompositesTableId5, ResultType = ResultType.DataTable>(dvdRental)
+    let actual = cmd.Execute().Rows.[0]
+    
+    Assert.Equal (Some 42L, actual.simple.some_number)
+    Assert.Equal (None, actual.simple.some_text)
+    Assert.Equal (Some [| 1; 2 |], actual.simple.some_array)
+
+[<Fact>]
+let ``Can pass composite type as parameter to update``() =
+    use cmd = DvdRental.CreateCommand<"update table_with_composites set  simple = @simple where id = 1">(dvdRental)
+    let actual = cmd.Execute(DvdRental.``public``.Types.simple_type ([| 1; 2 |], "blah", 42L))
+    
+    Assert.Equal (1, actual)
+
 //[<Literal>]
 //let lims = "Host=localhost;Username=postgres;Password=postgres;Database=lims"
 


### PR DESCRIPTION
Aims to implement #9. Does not currently support fields that are themselves composite types or enums (they're provided as `obj`, so it's possible to manually cast them).

```fsharp
use cmd = DvdRental.CreateCommand<"select * from table_with_composites">(cs)
let res = cmd.Execute()
let a = res.Head.complex.Value.nested_composite // Option<obj>
let b = res.[4].simple.some_array // Option<int64[]>
```