### PR TITLE
Fix column name error message

### DIFF
--- a/src/DesignTime/QuotationsFactory.fs
+++ b/src/DesignTime/QuotationsFactory.fs
@@ -198,8 +198,9 @@ type internal QuotationsFactory private() =
                 if sortColumns then columns |> List.sortBy (fun x -> x.Name) else columns
                 |> List.mapi (fun i col ->
                     let propertyName =
-                        if col.Name = "" then
-                            failwithf "Column #%i doesn't have name. Only columns with names accepted. Use explicit alias." (i + 1)
+                        if String.IsNullOrEmpty col.Name then
+                            let originalIndex = List.findIndex (fun x -> x = col) columns
+                            failwithf "Column #%i doesn't have a name. Only named columns are supported. Use an explicit alias." (originalIndex + 1)
                         else
                             col.Name
 

--- a/tests/Tests.fsproj
+++ b/tests/Tests.fsproj
@@ -29,7 +29,7 @@
   <ItemGroup>
     <PackageReference Include="System.ValueTuple" Version="4.5.0" />
     <PackageReference Include="Npgsql" Version="4.1.3" />
-    <PackageReference Include="Npgsql.LegacyPostgis" Version="1.0.0" />
+    <PackageReference Include="Npgsql.LegacyPostgis" Version="4.1.3" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="2.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.8.0" />
     <PackageReference Include="xunit" Version="2.4.0" />


### PR DESCRIPTION
When type reuse is on, columns are sorted alphabetically, and when the order is different in the original query, the index of a column that requires an alias is reported incorrectly.