### PR TITLE
Fix postgis params issue

### DIFF
--- a/src/DesignTime/InformationSchema.fs
+++ b/src/DesignTime/InformationSchema.fs
@@ -268,9 +268,6 @@ let inline openConnection connectionString =
 let extractParametersAndOutputColumns(connectionString, commandText, resultType, allParametersOptional, dbSchemaLookups : DbSchemaLookups) =
     use conn = openConnection(connectionString)
     
-    // deduce postgis types
-    conn.TypeMapper.UseNetTopologySuite() |> ignore
-    
     use cmd = new NpgsqlCommand(commandText, conn)
     NpgsqlCommandBuilder.DeriveParameters(cmd)
     for p in cmd.Parameters do p.Value <- DBNull.Value

--- a/src/DesignTime/InformationSchema.fs
+++ b/src/DesignTime/InformationSchema.fs
@@ -267,6 +267,9 @@ let inline openConnection connectionString =
 let extractParametersAndOutputColumns(connectionString, commandText, resultType, allParametersOptional, dbSchemaLookups : DbSchemaLookups) =
     use conn = openConnection(connectionString)
     
+    // deduce postgis types
+    conn.TypeMapper.UseNetTopologySuite() |> ignore
+    
     use cmd = new NpgsqlCommand(commandText, conn)
     NpgsqlCommandBuilder.DeriveParameters(cmd)
     for p in cmd.Parameters do p.Value <- DBNull.Value

--- a/src/DesignTime/InformationSchema.fs
+++ b/src/DesignTime/InformationSchema.fs
@@ -92,6 +92,7 @@ let private builtins = [
 
 let mutable private spatialTypesMapping = [
     "geometry", typeof<NetTopologySuite.Geometries.Geometry>
+    "geography", typeof<NetTopologySuite.Geometries.Geometry>
 ]
 
 let getTypeMapping = 

--- a/src/DesignTime/QuotationsFactory.fs
+++ b/src/DesignTime/QuotationsFactory.fs
@@ -482,12 +482,13 @@ type internal QuotationsFactory private() =
                 //let parameterName = p.Name.Substring 1
                 let parameterName = p.Name
 
-                let t = 
-                    if p.DataType.IsUserDefinedType
-                    then
-                        let t = customTypes.[p.DataType.UdtTypeName]
-                        if p.DataType.ClrType.IsArray then t.MakeArrayType() else upcast t 
-                    else p.DataType.ClrType
+                let t =
+                    let customType = customTypes.TryFind p.DataType.UdtTypeName
+                    
+                    match p.DataType.IsUserDefinedType, customType with
+                    | true, Some t -> 
+                        if p.DataType.ClrType.IsArray then t.MakeArrayType() else upcast t
+                    | _ -> p.DataType.ClrType
 
                 if p.Optional 
                 then 

--- a/src/DesignTime/TypeProviderAssembly.fs
+++ b/src/DesignTime/TypeProviderAssembly.fs
@@ -6,6 +6,7 @@ open Microsoft.FSharp.Core.CompilerServices
 open ProviderImplementation.ProvidedTypes
 open FSharp.Data.Npgsql.DesignTime
 open System.IO
+open Npgsql
 
 [<TypeProvider>]
 type NpgsqlProviders(config) as this = 
@@ -17,8 +18,12 @@ type NpgsqlProviders(config) as this =
     
     let cache = Cache<ProvidedTypeDefinition>()
     let schemaCache = Cache<DbSchemaLookups>()
+    
 
     do 
+        // register extension mappings
+        Npgsql.NpgsqlConnection.GlobalTypeMapper.UseNetTopologySuite() |> ignore
+    
         this.Disposing.Add <| fun _ ->
             try 
                 NpgsqlConnectionProvider.methodsCache.Clear()

--- a/tests/NpgsqlCmdTests.fs
+++ b/tests/NpgsqlCmdTests.fs
@@ -397,7 +397,7 @@ let asyncUpdateTable() =
         actors.Rows.[0].last_update <- DateTime.UtcNow
     
     Assert.Equal(1, actors.Update(conn, tx))
-
+    
 [<Fact>]
 let netTopologySuiteSimpleSelectPoint() =
     use conn = Connection.getWithNetTopologySuite()
@@ -412,6 +412,14 @@ let netTopologySuiteSimpleSelectPointConnStr() =
     let actual = cmd.Execute().Value.Value
     let expected = NetTopologySuite.Geometries.Point(x = 0., y = 0., SRID = 4)
     Assert.Equal(expected, downcast actual)
+
+[<Fact>]
+let netTopologySuiteSimpleParms() =
+    use conn = Connection.getWithNetTopologySuite()
+    use cmd = new NpgsqlCommand<"SELECT st_distance(@point, ST_GeomFromText('POINT(-12.5842 24.4944)',4))", dvdRental, SingleRow=true>(dvdRental)
+    let actual = cmd.Execute(point=NetTopologySuite.Geometries.Point(x = -12.5842, y = 24.4944, SRID = 4)).Value.Value
+    let expected = 0.0
+    Assert.Equal(expected, actual)
 
 type UpdateMovieRating = NpgsqlCommand<"UPDATE public.film SET rating = @rating WHERE rating = @oldRating AND title = @title", dvdRental>
 


### PR DESCRIPTION
Fixes the bug in 
https://github.com/demetrixbio/FSharp.Data.Npgsql/issues/84

The geometry reports itself as a user-defined type hence appears to crash when using the accessor, if not found, I just let try to deduce itself. 
